### PR TITLE
updated sqlite test for python3

### DIFF
--- a/tests/sqlite.py
+++ b/tests/sqlite.py
@@ -11,4 +11,4 @@ if __name__ == '__main__':
   row = db.executeOne("SELECT 2+3 as x;")
 
   assert row[0] == 5, "failed simple sql execution"
-  print ' * %s' % colored('ok', 'green')
+  print (' * %s' % colored('ok', 'green'))


### PR DESCRIPTION
Print in that file wasn't Python 3 conforming. It was generating a syntax error. Added leading and trailing parenthesis, which corrects the syntax error.